### PR TITLE
Bug Fix: Ensure style tag attributes are preserved during Vue 2 to Vue 3 conversion

### DIFF
--- a/tools/vue-composition-converter/index.vue
+++ b/tools/vue-composition-converter/index.vue
@@ -265,7 +265,7 @@ worker.addEventListener('message', (event: any) => {
 });
 
 const processCode = () => {
-	const { scriptContent, templateContent, styleContent } = parseSfc(userInput.value);
+	const { scriptContent, templateContent, styleContent, styleAttributes } = parseSfc(userInput.value);
 
 	errorMessage.value = '';
 
@@ -302,7 +302,8 @@ const processCode = () => {
 		const compositionOutput = composeSfc(
 			updatedCode.value,
 			templateContent,
-			styleContent
+			styleContent,
+			styleAttributes
 		);
 
 		updatedCode.value = compositionOutput;

--- a/tools/vue-composition-converter/tests/helpers.ts
+++ b/tools/vue-composition-converter/tests/helpers.ts
@@ -19,10 +19,10 @@ const parseCode = (input: string) => {
 };
 
 const formatCode = (input: string) => {
-	const { templateContent, scriptContent, styleContent } = parseSfc(input);
+	const { templateContent, scriptContent, styleContent, styleAttributes } = parseSfc(input);
 	const result = format(parseCode(scriptContent));
 
-	const composedSfc = composeSfc(result, templateContent, styleContent);
+	const composedSfc = composeSfc(result, templateContent, styleContent, styleAttributes);
 	return composedSfc;
 };
 

--- a/tools/vue-composition-converter/utils/parse-sfc.ts
+++ b/tools/vue-composition-converter/utils/parse-sfc.ts
@@ -2,6 +2,15 @@ import type { ElementNode } from '@vue/compiler-dom';
 import { parse } from '@vue/compiler-dom';
 
 /**
+ * Generates a string of attributes from an ElementNode.
+ */
+const getAttributesString = (node: ElementNode | undefined) => {
+	return node?.props?.map((prop) => {
+	  return `${prop.name}${prop.value ? `="${prop.value.content}"` : ''}`;
+	}).join(' ') || 'scoped';
+};
+
+/**
  * Parse SFC user input to extract template, script and style
  */
 const parseSfc = (sfcContent:string) => {
@@ -21,10 +30,13 @@ const parseSfc = (sfcContent:string) => {
 		return (node as ElementNode).tag === 'style';
 	});
 
+	const styleAttributes = getAttributesString(style as ElementNode);
+
 	return {
 		templateContent: template?.innerLoc.source,
 		scriptContent: script?.innerLoc.source,
 		styleContent: style?.innerLoc.source,
+		styleAttributes
 	};
 };
 
@@ -36,11 +48,12 @@ const parseSfc = (sfcContent:string) => {
 const composeSfc = (
 	scriptContent:string,
 	templateContent:string,
-	styleContent:string
+	styleContent:string,
+	styleAttributes:string
 ) => {
 	const templateSfc = `<template>${templateContent}</template>`;
 	let scriptSfc = `&lt;script setup&gt;\n${scriptContent}\n&lt;/script&gt;`;
-	const styleSfc = `<style scoped>${styleContent}</style>`;
+	const styleSfc = `<style ${styleAttributes}>${styleContent}</style>`;
 	scriptSfc = scriptSfc.replaceAll('&lt;', '<').replaceAll('&gt;', '>');
 	return [templateSfc, scriptSfc, styleSfc].join('\n\n');
 };

--- a/tools/vue-composition-converter/utils/parse-sfc.ts
+++ b/tools/vue-composition-converter/utils/parse-sfc.ts
@@ -7,7 +7,7 @@ import { parse } from '@vue/compiler-dom';
 const getAttributesString = (node: ElementNode | undefined) => {
 	return node?.props?.map((prop) => {
 	  return `${prop.name}${prop.value ? `="${prop.value.content}"` : ''}`;
-	}).join(' ') || 'scoped';
+	}).join(' ') || '';
 };
 
 /**
@@ -36,7 +36,7 @@ const parseSfc = (sfcContent:string) => {
 		templateContent: template?.innerLoc.source,
 		scriptContent: script?.innerLoc.source,
 		styleContent: style?.innerLoc.source,
-		styleAttributes
+		styleAttributes: styleAttributes || 'scoped'
 	};
 };
 


### PR DESCRIPTION
This pull request fixes an issue where the existing attributes for the <style> tag is not being preserved during the Vue 2 to Vue 3 conversion process.

Summary of changes:

- Ensured the composeSfc and parseSfc functions extracted and re-applied the existing attributes, and added scoped as the default if no attributes were present.
- Updated other references to include styleAttributes as a new parameter.

Preview before the fix - issue
![Issue](https://github.com/user-attachments/assets/14e110f8-a068-4ca7-b9cd-51b65c8858a7)

Preview after the fix
![after fix](https://github.com/user-attachments/assets/325d2eea-563e-4163-b41c-457fabbcc512)